### PR TITLE
use vendor neutral name instead of 'Google authenticator'

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/nextcloud/twofactor_totp/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/nextcloud/twofactor_totp/?branch=master)
 
 Tested with the following apps:
+* [FreeOTP Authenticator](https://play.google.com/store/apps/details?id=org.fedorahosted.freeotp) (open source)
 * [OTP Authenticator](https://github.com/0xbb/otp-authenticator) (open source) which can be downloaded from [F-Droid](https://f-droid.org/repository/browse/?fdfilter=totp&fdid=net.bierbaumer.otp_authenticator) and has a built-in QR-code reader.
 * [Google Authenticator](https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2) (proprietary)
 

--- a/lib/Activity/Setting.php
+++ b/lib/Activity/Setting.php
@@ -47,7 +47,7 @@ class Setting implements ISetting {
 	}
 
 	public function getName() {
-		return $this->l10n->t('TOTP (Google Authenticator)');
+		return $this->l10n->t('TOTP (Authenticator app)');
 	}
 
 	public function getPriority() {

--- a/lib/Provider/TotpProvider.php
+++ b/lib/Provider/TotpProvider.php
@@ -59,7 +59,7 @@ class TotpProvider implements IProvider {
 	 * @return string
 	 */
 	public function getDisplayName() {
-		return 'TOTP (Google Authenticator)';
+		return 'TOTP (Authenticator app)';
 	}
 
 	/**

--- a/tests/unit/Activity/SettingTest.php
+++ b/tests/unit/Activity/SettingTest.php
@@ -47,7 +47,7 @@ class SettingTest extends TestCase {
 		$this->assertEquals('twofactor_totp', $this->setting->getIdentifier());
 		$this->l10n->expects($this->once())
 			->method('t')
-			->with('TOTP (Google Authenticator)')
+			->with('TOTP (Authenticator app)')
 			->will($this->returnValue('TOTP (Google Authentifizierer)'));
 		$this->assertEquals('TOTP (Google Authentifizierer)', $this->setting->getName());
 		$this->assertEquals(10, $this->setting->getPriority());


### PR DESCRIPTION
Fixes https://github.com/nextcloud/twofactor_totp/issues/110

cc @tflidd @Yomark1 @Celti @r2evans