### PR TITLE
Use dedicated login button on 2fa challenge page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,10 +1,17 @@
 .totp-form {
 	margin: 16px auto 1px !important;
 }
-
-.challenge {
-	margin-top: 0 !important;
-	margin-left: 0 !important;
+.totp-form > input, .totp-form > button {
+	padding: 10px;
+	margin: 0px 0px 5px 0px;
+}
+.totp-form > input[type="tel"] {
+	width: 260px;
+}
+.totp-form > button[type="submit"] {
+	width: 280px;
+	border-radius: 3px;
+	font-size: 20px;
 }
 
 .confirm-inline {

--- a/templates/challenge.php
+++ b/templates/challenge.php
@@ -3,7 +3,9 @@ style('twofactor_totp', 'style');
 ?>
 
 <form method="POST" class="totp-form">
-	<input type="text" class="challenge" name="challenge" required="required" autofocus autocomplete="off" autocapitalize="off" placeholder="<?php p($l->t('Authentication code')) ?>">
-	<input type="submit" class="confirm-inline icon-confirm" value="">
+	<input type="tel" minlength="6" maxlength="6" name="challenge" required="required" autofocus autocomplete="off" autocapitalize="off" placeholder="<?php p($l->t('Authentication code')) ?>">
+	<button type="submit">
+		<span>Submit</span>
+	</button>
 	<p><?php p($l->t('Get the authentication code from the two-factor authentication app on your device.')) ?></p>
 </form>

--- a/tests/Acceptance/TOTPAcceptanceTest.php
+++ b/tests/Acceptance/TOTPAcceptanceTest.php
@@ -152,7 +152,7 @@ class TOTPAcceptenceTest extends PHPUnit_Framework_TestCase {
 
 		// Enter a wrong OTP
 		$this->webDriver->findElement(WebDriverBy::name('challenge'))->sendKeys('000');
-		$this->webDriver->findElement(WebDriverBy::cssSelector('input.confirm-inline.icon-confirm'))->click();
+		$this->webDriver->findElement(WebDriverBy::cssSelector('button[type="submit"]'))->click();
 
 		$this->assertEquals('http://localhost:8080/index.php/login/challenge/totp', $this->webDriver->getCurrentURL());
 	}


### PR DESCRIPTION
As requested by @skjnldsv in https://github.com/nextcloud/server/pull/2618#issuecomment-280082632.

Requires https://github.com/nextcloud/server/pull/3747

![bildschirmfoto von 2017-03-07 08-52-13](https://cloud.githubusercontent.com/assets/1374172/23647032/0444c100-0314-11e7-9c57-af1bb114d6a0.png)

Since this will introduce a design-incompatibility with server, we either have to backport the server PR, duplicate the styling or bump the min-required server version of this app.
