### PR TITLE
Let users confirm their TOTP setup before enforcing the provider

### DIFF
--- a/appinfo/database.xml
+++ b/appinfo/database.xml
@@ -27,6 +27,17 @@
                 <type>clob</type>
                 <notnull>true</notnull>
             </field>
+	    <!--
+		STATE 0 : disabled
+		STATE 1 : created (but not active)
+		STATE 2 : enabled
+	    -->
+	    <field>
+                <name>state</name>
+                <type>integer</type>
+		<default>2</default>
+                <notnull>true</notnull>
+            </field>
 
             <index>
                 <name>totp_secrets_user_id</name>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<name>Two Factor TOTP Provider</name>
 	<summary>TOTP two-factor provider</summary>
 	<description>A Two-Factor-Auth Provider for TOTP (RFC 6238)</description>
-	<version>1.1.0</version>
+	<version>1.2.0</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
 	<namespace>TwoFactorTOTP</namespace>

--- a/css/settings.css
+++ b/css/settings.css
@@ -2,3 +2,10 @@
 .nav-icon-totp-second-factor-auth {
 	background-image: url('../img/app-dark.svg?v=1');
 }
+
+.totp-loading {
+	display: inline-block;
+	vertical-align: sub;
+	margin-left: -2px;
+	margin-right: 4px;
+}

--- a/js/settingsview.js
+++ b/js/settingsview.js
@@ -1,15 +1,25 @@
-/* global Backbone, Handlebars, Promise */
+/* global Backbone, Handlebars, Promise, _ */
 
-(function (OC, Backbone, Handlebars, $) {
+(function (OC, Backbone, Handlebars, $, _) {
 	'use strict';
 
 	OC.Settings = OC.Settings || {};
 	OC.Settings.TwoFactorTotp = OC.Settings.TwoFactorTotp || {};
 
-	var TEMPLATE = '<div>'
-		+ '    <input type="checkbox" class="checkbox" id="totp-enabled">'
+	var STATE_DISABLED = 0;
+	var STATE_CREATED = 1;
+	var STATE_ENABLED = 2;
+
+	var TEMPLATE = ''
+		+ '{{#if loading}}'
+		+ '<span class="icon-loading-small totp-loading"></span>'
+		+ '<span>' + t('twofactor_totp', 'Enable TOTP') + '</span>'
+		+ '{{else}}'
+		+ '<div>'
+		+ '    <input type="checkbox" class="checkbox" id="totp-enabled" {{#if enabled}}checked{{/if}}>'
 		+ '    <label for="totp-enabled">' + t('twofactor_totp', 'Enable TOTP') + '</label>'
 		+ '</div>'
+		+ '{{/if}}'
 		+ '{{#if secret}}'
 		+ '<div>'
 		+ '    <span>' + t('twofactor_totp', 'This is your new TOTP secret:') + ' {{secret}}</span>'
@@ -17,39 +27,76 @@
 		+ '<div>'
 		+ '    <span>' + t('twofactor_totp', 'Scan this QR code with your TOTP app') + '<span><br>'
 		+ '    <img src="{{qr}}">'
-		+ '    </div>'
+		+ '</div>'
+		+ '<span>' + t('twofactor_totp', 'Once you have configured your app, enter a test code below to ensure that your app has been configured correctly.') + '<span><br>'
+		+ '<input id="totp-confirmation" type="tel" minlength="6" maxlength="6" autocomplete="off" autocapitalize="off" placeholder="' + t('twofactor_totp', 'Authentication code') + '">'
+		+ '<input id="totp-confirmation-submit" type="button" value="' + t('twofactor_totp', 'Verify') + '">'
 		+ '{{/if}}';
 
 	var View = Backbone.View.extend({
+
+		/** @type {function} */
 		template: Handlebars.compile(TEMPLATE),
+
+		/** @type {bool} */
 		_loading: undefined,
-		_enabled: undefined,
+
+		/** @type {string} */
+		_qr: undefined,
+
+		/** @type {string} */
+		_secret: undefined,
+
+		/** @type {int} */
+		_state: undefined,
+
 		events: {
-			'change #totp-enabled': '_onToggleEnabled'
+			'change #totp-enabled': '_onToggleEnabled',
+			'click #totp-confirmation-submit': '_enableTOTP',
+			'keydown #totp-confirmation': '_onConfirmKeyDown'
 		},
+
+		/**
+		 * @returns {undefined}
+		 */
 		initialize: function () {
 			this._load();
 		},
-		render: function (data) {
-			this.$el.html(this.template(data));
+
+		/**
+		 * @param {Object} data
+		 * @returns {undefined}
+		 */
+		render: function () {
+			this.$el.html(this.template({
+				loading: this._loading,
+				secret: this._secret,
+				qr: this._qr,
+				enabled: this._state === STATE_ENABLED
+			}));
 		},
+
+		/**
+		 * @returns {undefined}
+		 */
 		_load: function () {
 			this._loading = true;
+			this.render();
 
 			var url = OC.generateUrl('/apps/twofactor_totp/settings/state');
-			var loading = $.ajax(url, {
+			Promise.resolve($.ajax(url, {
 				method: 'GET'
-			});
-
-			var _this = this;
-			$.when(loading).done(function (data) {
-				_this._enabled = data.enabled;
-				_this.$('#totp-enabled').attr('checked', data.enabled);
-			});
-			$.when(loading).always(function () {
-				_this._loading = false;
-			});
+			})).then(function (data) {
+				this._state = data.state ? STATE_ENABLED : STATE_DISABLED;
+			}.bind(this), console.error.bind(this)).then(function () {
+				this._loading = false;
+				this.render();
+			}.bind(this));
 		},
+
+		/**
+		 * @returns {Promise}
+		 */
 		_onToggleEnabled: function () {
 			if (this._loading) {
 				// Ignore event
@@ -58,27 +105,121 @@
 
 			var enabled = this.$('#totp-enabled').is(':checked');
 
-			if (enabled !== this._enabled) {
-				var url = OC.generateUrl('/apps/twofactor_totp/settings/enable');
-				this._loading = true;
-				this._enabled = enabled;
-
-				var _this = this;
-				this._requirePasswordConfirmation().then(function () {
-					return Promise.resolve($.ajax(url, {
-						method: 'POST',
-						data: {
-							state: enabled
-						}
-					}));
-				}).then(function(data) {
-					_this._enabled = data.enabled;
-					_this._showQr(data);
-					_this.$('#totp-enabled').attr('checked', data.enabled);
-				}).catch(console.error.bind(this)).then(function() {
-					_this._loading = false;
-				});
+			if (!!enabled) {
+				return this._createTOTP();
+			} else {
+				return this._disableTOTP();
 			}
+		},
+
+		/**
+		 * Create a new secret on the server, which will be inactive until the
+		 * user confirms their app is working by providing a OTP once.
+		 *
+		 * @returns {Promise}
+		 */
+		_createTOTP: function () {
+			this._loading = true;
+			// Show loading spinner
+			this.render();
+
+			return this._updateServerState({
+				state: STATE_CREATED
+			}).then(function () {
+				// If the stat could be changed, keep showing the loading
+				// spinner until the user has finished the registration
+				this._loading = this._state === STATE_CREATED;
+				this.render();
+			}.bind(this), function() {
+				// Restore on error
+				this._loading = false;
+				this.render();
+			}).catch(console.error.bind(this));
+		},
+
+		/**
+		 * Also enable TOTP if the user presses enter inside the confirmation
+		 * input
+		 *
+		 * @param {Event} e
+		 * @returns {undefined}
+		 */
+		_onConfirmKeyDown: function(e) {
+			if (e.which === 13) {
+				this._enableTOTP();
+			}
+		},
+
+		/**
+		 * Enable the previously created TOTP secret by sending a OTP
+		 * to the server for confirmation.
+		 *
+		 * @returns {Promise}
+		 */
+		_enableTOTP: function () {
+			var key = this.$('#totp-confirmation').val();
+
+			this._loading = true;
+			// Show loading spinner and disable input elements
+			this.render();
+			this.$('input').prop('disabled', true);
+
+			return this._updateServerState({
+				state: STATE_ENABLED,
+				key: key
+			}).then(function () {
+				this.$('input').prop('disabled', false);
+				if (this._state === STATE_ENABLED) {
+					// Success
+					this._loading = false;
+					this._qr = undefined;
+					this._secret = undefined;
+				} else {
+					OC.Notification.showTemporary(t('twofactor_totp', 'Could not verify your key. Please try again'));
+				}
+				this.render();
+			}.bind(this), console.error.bind(this));
+		},
+
+		/**
+		 * @returns {Promise}
+		 */
+		_disableTOTP: function () {
+			this._loading = true;
+			// Show loading spinner
+			this.render();
+
+			return this._updateServerState({
+				state: STATE_DISABLED
+			}).then(function () {
+				this._loading = false;
+				this.render();
+			}.bind(this), console.error.bind(this));
+		},
+
+		/**
+		 * @param {Object} data
+		 * @param {int} data.state
+		 * @returns {Promise}
+		 */
+		_updateServerState: function (data) {
+			var url = OC.generateUrl('/apps/twofactor_totp/settings/enable');
+			return this._requirePasswordConfirmation().then(function () {
+				return $.ajax(url, {
+					method: 'POST',
+					data: data
+				});
+			}).then(function (data) {
+				this._state = data.state;
+				// Optional response: qr, secret
+				if (!_.isUndefined(data.qr) && !_.isUndefined(data.secret)) {
+					this._qr = data.qr;
+					this._secret = data.secret;
+				}
+			}.bind(this), function () {
+				console.error(arguments);
+				throw new Error('twofactor_totp', 'Error while communicating with the server');
+			});
 		},
 
 		/**
@@ -91,20 +232,10 @@
 			return new Promise(function (resolve) {
 				OC.PasswordConfirmation.requirePasswordConfirmation(resolve);
 			});
-		},
-
-		/**
-		 * @param {object} data
-		 * @returns {undefined}
-		 */
-		_showQr: function (data) {
-			this.render({
-				secret: data.secret,
-				qr: data.qr
-			});
 		}
+
 	});
 
 	OC.Settings.TwoFactorTotp.View = View;
 
-})(OC, Backbone, Handlebars, $);
+})(OC, Backbone, Handlebars, $, _);

--- a/lib/Db/TotpSecret.php
+++ b/lib/Db/TotpSecret.php
@@ -28,13 +28,18 @@ use OCP\AppFramework\Db\Entity;
  * @method void setUserId(string $userId)
  * @method string getSecret()
  * @method void setSecret(string $secret)
+ * @method int getState()
+ * @method void setState(int $state)
  */
 class TotpSecret extends Entity {
 
-    /** @var string */
-    protected $userId;
+	/** @var string */
+	protected $userId;
 
-    /** @var string */
-    protected $secret;
+	/** @var string */
+	protected $secret;
+
+	/** @var int */
+	protected $state;
 
 }

--- a/lib/Db/TotpSecretMapper.php
+++ b/lib/Db/TotpSecretMapper.php
@@ -42,7 +42,7 @@ class TotpSecretMapper extends Mapper {
         /* @var $qb IQueryBuilder */
         $qb = $this->db->getQueryBuilder();
 
-        $qb->select('id', 'user_id', 'secret')
+        $qb->select('id', 'user_id', 'secret', 'state')
                 ->from('twofactor_totp_secrets')
                 ->where($qb->expr()->eq('user_id', $qb->createNamedParameter($user->getUID())));
         $result = $qb->execute();

--- a/lib/Service/ITotp.php
+++ b/lib/Service/ITotp.php
@@ -26,26 +26,46 @@ use OCP\IUser;
 
 interface ITotp {
 
-    /**
-     * @param IUser $user
-     */
-    public function hasSecret(IUser $user);
+	const STATE_DISABLED = 0;
+	const STATE_CREATED = 1;
+	const STATE_ENABLED = 2;
 
-    /**
-     * @param IUser $user
-     * @return string the newly created secret
-     * @throws TotpSecretAlreadySet
-     */
-    public function createSecret(IUser $user);
+	/**
+	 * @param IUser $user
+	 */
+	public function hasSecret(IUser $user);
 
-    /**
-     * @param IUser $user
-     */
-    public function deleteSecret(IUser $user);
+	/**
+	 * Create a new secret
+	 *
+	 * Note: the newly generated secret is disabled by default, because
+	 * the user should once confirm that the OTP app was set up successfully.
+	 *
+	 * @param IUser $user
+	 * @return string the newly created secret
+	 * @throws TotpSecretAlreadySet
+	 */
+	public function createSecret(IUser $user);
 
-    /**
-     * @param IUser $user
-     * @param string $key
-     */
-    public function validateSecret(IUser $user, $key);
+	/**
+	 * Enable OTP for the given user. The secret has to be generated
+	 * beforehand, using ITotp::createSecret
+	 *
+	 * @param IUser $user
+	 * @param string $key for verification
+	 * @return bool whether the key is valid and the secret has been enabled
+	 * @throws DoesNotExistException
+	 */
+	public function enable(IUser $user, $key);
+
+	/**
+	 * @param IUser $user
+	 */
+	public function deleteSecret(IUser $user);
+
+	/**
+	 * @param IUser $user
+	 * @param string $key
+	 */
+	public function validateSecret(IUser $user, $key);
 }

--- a/tests/Acceptance/TOTPAcceptanceTest.php
+++ b/tests/Acceptance/TOTPAcceptanceTest.php
@@ -22,6 +22,7 @@
 
 namespace OCA\TwoFactorTOTP\Tests\Acceptance;
 
+use Base32\Base32;
 use Facebook\WebDriver\Exception\ElementNotSelectableException;
 use Facebook\WebDriver\WebDriver;
 use Facebook\WebDriver\WebDriverBy;
@@ -29,9 +30,12 @@ use Facebook\WebDriver\WebDriverExpectedCondition;
 use OC;
 use OCA\TwoFactorTOTP\Db\TotpSecret;
 use OCA\TwoFactorTOTP\Db\TotpSecretMapper;
+use OCA\TwoFactorTOTP\Service\ITotp;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\IUser;
 use Otp\GoogleAuthenticator;
+use Otp\Otp;
+use PHPUnit_Framework_AssertionFailedError;
 
 /**
  * @group Acceptance
@@ -80,17 +84,17 @@ class TOTPAcceptenceTest extends AcceptanceTest {
 		$this->webDriver->findElement(WebDriverBy::cssSelector('form[name=login] input[type=submit]'))->click();
 
 		// Go to personal settings
-		$this->webDriver->wait(20, 1000)->until(WebDriverExpectedCondition::elementToBeClickable(WebDriverBy::id('expandDisplayName')));
+		$this->webDriver->wait(20, 200)->until(WebDriverExpectedCondition::elementToBeClickable(WebDriverBy::id('expandDisplayName')));
 		$this->webDriver->findElement(WebDriverBy::id('expandDisplayName'))->click();
 		$this->webDriver->findElement(WebDriverBy::linkText('Personal'))->click();
 
 		// Go to TOTP settings
-		$this->webDriver->wait(20, 1000)->until(WebDriverExpectedCondition::elementToBeClickable(WebDriverBy::linkText('TOTP second-factor auth')));
+		$this->webDriver->wait(20, 200)->until(WebDriverExpectedCondition::elementToBeClickable(WebDriverBy::linkText('TOTP second-factor auth')));
 		$this->webDriver->findElement(WebDriverBy::linkText('TOTP second-factor auth'))->click();
 
 		// Enable TOTP
-		usleep(15 * 1000 * 1000); // Hard-coded sleep because the scripts need some time load the page
-		$this->webDriver->wait(20, 1000)->until(function(WebDriver $driver) {
+		// Wait for state being loaded from the server
+		$this->webDriver->wait(20, 200)->until(function(WebDriver $driver) {
 			try {
 				return count($driver->findElements(WebDriverBy::id('totp-enabled'))) > 0;
 			} catch (ElementNotSelectableException $ex) {
@@ -100,7 +104,47 @@ class TOTPAcceptenceTest extends AcceptanceTest {
 		$this->webDriver->executeScript('arguments[0].click(); console.log(arguments[0]);', [
 			$this->webDriver->findElement(WebDriverBy::id('totp-enabled')),
 		]);
-		$this->webDriver->wait(20, 1000)->until(WebDriverExpectedCondition::elementTextContains(WebDriverBy::id('twofactor-totp-settings'), 'This is your new TOTP secret:'));
+		$this->webDriver->wait(15, 200)->until(WebDriverExpectedCondition::elementTextContains(WebDriverBy::id('twofactor-totp-settings'), 'This is your new TOTP secret:'));
+		$this->assertHasSecret(ITotp::STATE_CREATED);
+
+		// Enter a wrong OTP
+		$this->webDriver->findElement(WebDriverBy::id('totp-confirmation'))->sendKeys('000000');
+		$this->webDriver->findElement(WebDriverBy::id('totp-confirmation-submit'))->click();
+
+		// Wait for the notification
+		$this->webDriver->wait(15, 200)->until(WebDriverExpectedCondition::elementTextContains(WebDriverBy::id('notification'), 'Could not verify your key. Please try again'));
+
+		// Enter a correct OTP
+		$this->webDriver->findElement(WebDriverBy::id('totp-confirmation'))->sendKeys($this->getValidTOTP());
+		$this->webDriver->findElement(WebDriverBy::id('totp-confirmation-submit'))->click();
+
+		// Try to locate checked checkbox
+		$this->webDriver->wait(20, 200)->until(function(WebDriver $driver) {
+			try {
+				return $driver->findElement(WebDriverBy::id('totp-enabled'))->getAttribute('checked') === 'true';
+			} catch (ElementNotSelectableException $ex) {
+				return false;
+			}
+		});
+		$this->assertHasSecret(ITotp::STATE_ENABLED);
+	}
+
+	private function assertHasSecret($state) {
+		try {
+			$secret = $this->secretMapper->getSecret($this->user);
+			if ($state !== (int) $secret->getState()) {
+				throw new PHPUnit_Framework_AssertionFailedError('TOTP secret has wrong state');
+			}
+		} catch (DoesNotExistException $ex) {
+			throw new PHPUnit_Framework_AssertionFailedError('User does not have a totp secret');
+		}
+	}
+
+	private function getValidTOTP() {
+		$dbSecret = $this->secretMapper->getSecret($this->user);
+		$secret = OC::$server->getCrypto()->decrypt($dbSecret->getSecret());
+		$otp = new Otp();
+		return $otp->totp(Base32::decode($secret));
 	}
 
 	private function createSecret() {
@@ -123,7 +167,7 @@ class TOTPAcceptenceTest extends AcceptanceTest {
 		$this->webDriver->findElement(WebDriverBy::id('password'))->sendKeys('admin');
 		$this->webDriver->findElement(WebDriverBy::cssSelector('form[name=login] input[type=submit]'))->click();
 
-		$this->webDriver->wait(20, 1000)->until(function(WebDriver $driver) {
+		$this->webDriver->wait(20, 200)->until(function(WebDriver $driver) {
 			try {
 				return $driver->findElements(WebDriverBy::className('totp-form'));
 			} catch (ElementNotSelectableException $ex) {
@@ -135,7 +179,7 @@ class TOTPAcceptenceTest extends AcceptanceTest {
 		$this->webDriver->findElement(WebDriverBy::name('challenge'))->sendKeys('000000');
 		$this->webDriver->findElement(WebDriverBy::cssSelector('button[type="submit"]'))->submit();
 
-		$this->webDriver->wait(20, 1000)->until(WebDriverExpectedCondition::elementTextContains(WebDriverBy::className('warning'), 'Error while validating your second factor'));
+		$this->webDriver->wait(20, 200)->until(WebDriverExpectedCondition::elementTextContains(WebDriverBy::className('warning'), 'Error while validating your second factor'));
 
 		$this->assertEquals('http://localhost:8080/index.php/login/challenge/totp', $this->webDriver->getCurrentURL());
 	}


### PR DESCRIPTION
Users might have trouble get their TOTP app to work. By checking
whether their basic setup is configured correctly, we lower the
risk of users being locked out unexpectedly.

TODO
- [x] The 2FA provider must not be used before the user confirmed that the TOTP setup works by providing a sample key
- [x] Better UI and UX, maybe by splitting the interaction into different steps the user has to complete.
- [x] Tests

Fixes https://github.com/nextcloud/twofactor_totp/issues/22