### PR TITLE
Fix Backbone namespacing

### DIFF
--- a/js/settingsview.js
+++ b/js/settingsview.js
@@ -238,4 +238,4 @@
 
 	OC.Settings.TwoFactorTotp.View = View;
 
-})(OC, Backbone, Handlebars, $, _);
+})(OC, OC.Backbone, Handlebars, $, _);


### PR DESCRIPTION
cc @rullzer @ChristophWurst 

Caused by https://github.com/nextcloud/server/pull/3994

Before: No settings present
After: Settings present