### PR TITLE
Fix provider state population to the server registry

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<name>Two Factor TOTP Provider</name>
 	<summary>TOTP two-factor provider</summary>
 	<description>A Two-Factor-Auth Provider for TOTP (RFC 6238)</description>
-	<version>1.4.1</version>
+	<version>1.5.0</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
 	<namespace>TwoFactorTOTP</namespace>

--- a/composer.lock
+++ b/composer.lock
@@ -1,7 +1,7 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
     "content-hash": "2383bb1241bfbf11ed85f4df472c571b",
@@ -163,12 +163,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ChristophWurst/nextcloud_composer.git",
-                "reference": "9275d848ddec5a84cf21319bab07951a75af12d2"
+                "reference": "499dfadc8f8694915f49730c69829c03eace56d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ChristophWurst/nextcloud_composer/zipball/9275d848ddec5a84cf21319bab07951a75af12d2",
-                "reference": "9275d848ddec5a84cf21319bab07951a75af12d2",
+                "url": "https://api.github.com/repos/ChristophWurst/nextcloud_composer/zipball/499dfadc8f8694915f49730c69829c03eace56d8",
+                "reference": "499dfadc8f8694915f49730c69829c03eace56d8",
                 "shasum": ""
             },
             "type": "library",
@@ -188,7 +188,7 @@
                 }
             ],
             "description": "Composer package containing Nextcloud's public API (classes, interfaces)",
-            "time": "2018-04-05T07:16:03+00:00"
+            "time": "2018-07-26T15:23:17+00:00"
         },
         {
             "name": "endroid/qr-code",

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -26,6 +26,7 @@ namespace OCA\TwoFactorTOTP\AppInfo;
 use OCA\TwoFactorTOTP\Event\StateChanged;
 use OCA\TwoFactorTOTP\Listener\IListener;
 use OCA\TwoFactorTOTP\Listener\StateChangeActivity;
+use OCA\TwoFactorTOTP\Listener\StateChangeRegistryUpdater;
 use OCA\TwoFactorTOTP\Service\ITotp;
 use OCA\TwoFactorTOTP\Service\Totp;
 use OCP\AppFramework\App;
@@ -43,6 +44,7 @@ class Application extends App {
 			/** @var IListener[] $listeners */
 			$listeners = [
 				$container->query(StateChangeActivity::class),
+				$container->query(StateChangeRegistryUpdater::class),
 			];
 
 			foreach ($listeners as $listener) {

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 /**
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>
@@ -23,6 +23,9 @@ declare(strict_types = 1);
 
 namespace OCA\TwoFactorTOTP\AppInfo;
 
+use OCA\TwoFactorTOTP\Event\StateChanged;
+use OCA\TwoFactorTOTP\Listener\IListener;
+use OCA\TwoFactorTOTP\Listener\StateChangeActivity;
 use OCA\TwoFactorTOTP\Service\ITotp;
 use OCA\TwoFactorTOTP\Service\Totp;
 use OCP\AppFramework\App;
@@ -34,6 +37,18 @@ class Application extends App {
 
 		$container = $this->getContainer();
 		$container->registerAlias(ITotp::class, Totp::class);
+
+		$dispatcher = $container->getServer()->getEventDispatcher();
+		$dispatcher->addListener(StateChanged::class, function (StateChanged $event) use ($container) {
+			/** @var IListener[] $listeners */
+			$listeners = [
+				$container->query(StateChangeActivity::class),
+			];
+
+			foreach ($listeners as $listener) {
+				$listener->handle($event);
+			}
+		});
 	}
 
 }

--- a/lib/Event/StateChanged.php
+++ b/lib/Event/StateChanged.php
@@ -1,7 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @copyright Copyright (c) 2018 Christoph Wurst <christoph@winzerhof-wurst.at>
  *
  * Two-factor TOTP
  *
@@ -19,4 +22,36 @@
  *
  */
 
-include_once __DIR__ . '/../vendor/autoload.php';
+namespace OCA\TwoFactorTOTP\Event;
+
+use OCP\IUser;
+use Symfony\Component\EventDispatcher\Event;
+
+class StateChanged extends Event {
+
+	/** @var IUser */
+	private $user;
+
+	/** @var bool */
+	private $enabled;
+
+	public function __construct(IUser $user, bool $enabled) {
+		$this->user = $user;
+		$this->enabled = $enabled;
+	}
+
+	/**
+	 * @return IUser
+	 */
+	public function getUser(): IUser {
+		return $this->user;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function isEnabled(): bool {
+		return $this->enabled;
+	}
+
+}

--- a/lib/Listener/IListener.php
+++ b/lib/Listener/IListener.php
@@ -1,7 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @copyright Copyright (c) 2018 Christoph Wurst <christoph@winzerhof-wurst.at>
  *
  * Two-factor TOTP
  *
@@ -19,4 +22,12 @@
  *
  */
 
-include_once __DIR__ . '/../vendor/autoload.php';
+namespace OCA\TwoFactorTOTP\Listener;
+
+use Symfony\Component\EventDispatcher\Event;
+
+interface IListener {
+
+	public function handle(Event $event);
+
+}

--- a/lib/Listener/StateChangeActivity.php
+++ b/lib/Listener/StateChangeActivity.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @copyright Copyright (c) 2018 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * Two-factor TOTP
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\TwoFactorTOTP\Listener;
+
+use OCA\TwoFactorTOTP\Event\StateChanged;
+use OCP\Activity\IManager as ActivityManager;
+use Symfony\Component\EventDispatcher\Event;
+
+class StateChangeActivity implements IListener {
+
+	/** @var ActivityManager */
+	private $activityManager;
+
+	public function __construct(ActivityManager $activityManager) {
+		$this->activityManager = $activityManager;
+	}
+
+	public function handle(Event $event) {
+		if ($event instanceof StateChanged) {
+			$user = $event->getUser();
+			$subject = $event->isEnabled() ? 'totp_enabled_subject' : 'totp_disabled_subject';
+
+			$activity = $this->activityManager->generateEvent();
+			$activity->setApp('twofactor_totp')
+				->setType('security')
+				->setAuthor($user->getUID())
+				->setAffectedUser($user->getUID());
+			$activity->setSubject($subject);
+			$this->activityManager->publish($activity);
+		}
+	}
+}

--- a/lib/Listener/StateChangeRegistryUpdater.php
+++ b/lib/Listener/StateChangeRegistryUpdater.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @copyright Copyright (c) 2018 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * Two-factor TOTP
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\TwoFactorTOTP\Listener;
+
+use OCA\TwoFactorTOTP\Event\StateChanged;
+use OCA\TwoFactorTOTP\Provider\TotpProvider;
+use OCP\Authentication\TwoFactorAuth\IRegistry;
+use Symfony\Component\EventDispatcher\Event;
+
+class StateChangeRegistryUpdater implements IListener {
+
+	/** @var IRegistry */
+	private $registry;
+
+	/** @var TotpProvider */
+	private $provider;
+
+	public function __construct(IRegistry $registry, TotpProvider $provider) {
+		$this->registry = $registry;
+		$this->provider = $provider;
+	}
+
+	public function handle(Event $event) {
+		if ($event instanceof StateChanged) {
+			if ($event->isEnabled()) {
+				$this->registry->enableProviderFor($this->provider, $event->getUser());
+			} else {
+				$this->registry->disableProviderFor($this->provider, $event->getUser());
+			}
+		}
+	}
+}

--- a/tests/Unit/Event/StateChangedTest.php
+++ b/tests/Unit/Event/StateChangedTest.php
@@ -1,7 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @copyright Copyright (c) 2018 Christoph Wurst <christoph@winzerhof-wurst.at>
  *
  * Two-factor TOTP
  *
@@ -19,4 +22,30 @@
  *
  */
 
-include_once __DIR__ . '/../vendor/autoload.php';
+namespace OCA\TwoFactorTOTP\Unit\Event;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\TwoFactorTOTP\Event\StateChanged;
+use OCP\IUser;
+
+class StateChangedTest extends TestCase {
+
+	public function testEnabled() {
+		$user = $this->createMock(IUser::class);
+		$event = new StateChanged($user, true);
+
+		$enabled = $event->isEnabled();
+
+		$this->assertTrue($enabled);
+	}
+
+	public function testDisabled() {
+		$user = $this->createMock(IUser::class);
+		$event = new StateChanged($user, false);
+
+		$enabled = $event->isEnabled();
+
+		$this->assertFalse($enabled);
+	}
+
+}

--- a/tests/Unit/Listener/StateChangeActivityTest.php
+++ b/tests/Unit/Listener/StateChangeActivityTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @copyright Copyright (c) 2018 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * Two-factor TOTP
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\TwoFactorTOTP\Unit\Listener;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\TwoFactorTOTP\Event\StateChanged;
+use OCA\TwoFactorTOTP\Listener\StateChangeActivity;
+use OCP\Activity\IEvent;
+use OCP\Activity\IManager;
+use OCP\IUser;
+
+class StateChangeActivityTest extends TestCase {
+
+	/** @var StateChangeActivity */
+	private $listener;
+
+	/** @var IManager */
+	private $activityManager;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->activityManager = $this->createMock(IManager::class);
+
+		$this->listener = new StateChangeActivity($this->activityManager);
+	}
+
+	public function testHandleStateEvent() {
+		$uid = 'user234';
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+		$event = new StateChanged($user, true);
+		$activityEvent = $this->createMock(IEvent::class);
+		$this->activityManager->expects($this->once())
+			->method('generateEvent')
+			->willReturn($activityEvent);
+		$activityEvent->expects($this->once())
+			->method('setApp')
+			->with('twofactor_totp')
+			->willReturnSelf();
+		$activityEvent->expects($this->once())
+			->method('setType')
+			->with('security')
+			->willReturnSelf();
+		$activityEvent->expects($this->once())
+			->method('setAuthor')
+			->with($uid)
+			->willReturnSelf();
+		$activityEvent->expects($this->once())
+			->method('setAffectedUser')
+			->with($uid)
+			->willReturnSelf();
+		$this->activityManager->expects($this->once())
+			->method('publish')
+			->with($activityEvent);
+
+		$this->listener->handle($event);
+	}
+
+}

--- a/tests/Unit/Listener/StateChangeRegistryUpdaterTest.php
+++ b/tests/Unit/Listener/StateChangeRegistryUpdaterTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: christoph
+ * Date: 31.07.18
+ * Time: 06:33
+ */
+
+namespace OCA\TwoFactorTOTP\Test\Listener;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\TwoFactorTOTP\Event\StateChanged;
+use OCA\TwoFactorTOTP\Listener\StateChangeRegistryUpdater;
+use OCA\TwoFactorTOTP\Provider\TotpProvider;
+use OCP\Authentication\TwoFactorAuth\IRegistry;
+use OCP\IUser;
+use Symfony\Component\EventDispatcher\Event;
+
+class StateChangeRegistryUpdaterTest extends TestCase {
+
+	/** @var StateChangeRegistryUpdater */
+	private $listener;
+
+	/** @var IRegistry */
+	private $registry;
+
+	/** @var TotpProvider */
+	private $provider;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->registry = $this->createMock(IRegistry::class);
+		$this->provider = $this->createMock(TotpProvider::class);
+
+		$this->listener = new StateChangeRegistryUpdater($this->registry, $this->provider);
+	}
+
+	public function testIgnoresGenericEvent() {
+		$event = $this->createMock(Event::class);
+		$this->registry->expects($this->never())
+			->method('enableProviderFor');
+		$this->registry->expects($this->never())
+			->method('disableProviderFor');
+
+		$this->listener->handle($event);
+	}
+
+	public function testProviderEnabledEvent() {
+		$user = $this->createMock(IUser::class);
+		$event = new StateChanged($user, true);
+		$this->registry->expects($this->once())
+			->method('enableProviderFor')
+			->with($this->provider, $user);
+
+		$this->listener->handle($event);
+	}
+
+	public function testProviderDisabledEvent() {
+		$user = $this->createMock(IUser::class);
+		$event = new StateChanged($user, false);
+		$this->registry->expects($this->once())
+			->method('disableProviderFor')
+			->with($this->provider, $user);
+
+		$this->listener->handle($event);
+	}
+
+}


### PR DESCRIPTION
Required for https://github.com/orgs/nextcloud/projects/4#card-10826964

This PR consists of two parts. First, a little refactoring to decouple some logic from the provider to decouple it from the necessary action on enabled/disabled state change via the server event system. Second, it adds a new state change listener that populates the state to the server's provider registry.

@rullzer please have a look :)

- [x] Requires https://github.com/nextcloud/server/pull/10462
- [x] TODO: remove last commit that changes the core branch