### PR TITLE
Fix php's built in dev server on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,9 +93,9 @@ matrix:
       env: "DB=pgsql PHP_COVERAGE=TRUE"
     - php: 7.2
       env: "DB=mysql"
-    - php: 7.2
+    - php: 7.1
       env: "DB=mysql SAUCE=TRUE SELENIUM_BROWSER=firefox"
-    - php: 7.2
+    - php: 7.1
       env: "DB=mysql SAUCE=TRUE SELENIUM_BROWSER=chrome"
 
   fast_finish: true


### PR DESCRIPTION
(hopefully)

The dev server segfaults in https://github.com/nextcloud/twofactor_totp/pull/264, so this is an attempt in changing it's version and hoping that php7.1 one is not affected :crossed_fingers: 