### PR TITLE
Fix acceptance tests to match the restructured 2FA pages in nc15

### DIFF
--- a/tests/Acceptance/TOTPAcceptanceTest.php
+++ b/tests/Acceptance/TOTPAcceptanceTest.php
@@ -169,7 +169,7 @@ class TOTPAcceptenceTest extends TestCase {
 		$this->webDriver->findElement(WebDriverBy::name('challenge'))->sendKeys('000000');
 		$this->webDriver->findElement(WebDriverBy::cssSelector('button[type="submit"]'))->submit();
 
-		$this->webDriver->wait(20, 200)->until(WebDriverExpectedCondition::elementTextContains(WebDriverBy::className('warning'), 'Error while validating your second factor'));
+		$this->webDriver->wait(20, 200)->until(WebDriverExpectedCondition::elementTextContains(WebDriverBy::className('body-login-container'), 'Error while validating your second factor'));
 
 		$this->assertEquals('http://localhost:8080/index.php/login/challenge/totp', $this->webDriver->getCurrentURL());
 	}


### PR DESCRIPTION
Broken as of https://github.com/nextcloud/server/commit/ae2cd50427633e13ed89177715c3b277d3ea1bf7.