### PR TITLE
Add KeePassXC info

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Tested with the following apps:
 * [FreeOTP Authenticator](https://freeotp.github.io/) (open source) Availabe via [F-droid](https://f-droid.org/en/packages/org.fedorahosted.freeotp/), [Google Play](https://play.google.com/store/apps/details?id=org.fedorahosted.freeotp), and [Apple's App Store](https://itunes.apple.com/us/app/freeotp-authenticator/id872559395?mt=8)
 * [OTP Authenticator](https://github.com/0xbb/otp-authenticator) (open source) Availabe via [F-Droid](https://f-droid.org/en/packages/net.bierbaumer.otp_authenticator/) and [Google Play](https://play.google.com/store/apps/details?id=net.bierbaumer.otp_authenticator). It features a built-in QR-code reader.
 * [Google Authenticator](https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2) (proprietary)
+* [KeePassXC (Linux, Windows, macOS)](https://keepassxc.org/) (open-source) Aviabilabe via [download](https://keepassxc.org/download/), package repositorys or [GitHub](http://www.github.com/keepassxreboot/keepassxc/) (Keepass also provides a plugin and Keepass2Android allows to use TOTP token)
 
 ## Enabling TOTP 2FA for your account
 ![](screenshots/enter_challenge.png)


### PR DESCRIPTION
fixes https://github.com/nextcloud/twofactor_totp/issues/318

Cross-plattform application (QT-based frontend) frok of https://github.com/keepassx/keepassx (inactive)  and uses on windows only Keepass file.

Menu
![image](https://user-images.githubusercontent.com/1295633/48638486-1126eb00-e9d1-11e8-829d-21555599621a.png)

Setup options
![image](https://user-images.githubusercontent.com/1295633/48638509-21d76100-e9d1-11e8-9590-27067d1a3145.png)

Show TOTP
![image](https://user-images.githubusercontent.com/1295633/48638534-3287d700-e9d1-11e8-90d9-9ba6e7539cde.png)
