### PR TITLE
Do not package .git directory from vendor

### DIFF
--- a/krankerl.toml
+++ b/krankerl.toml
@@ -22,6 +22,7 @@ exclude = [
 	"src",
 	"tests",
 	"vendor/bin",
+	"vendor/christophwurst/nextcloud/.git",
 	"vendor/endroid/qr-code/assets",
 ]
 


### PR DESCRIPTION
Fixes https://github.com/nextcloud/twofactor_totp/issues/367

This is necessary because the dependency is installed via git.