### PR TITLE
Fix first migration from an old database schema

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<name>Two-Factor TOTP Provider</name>
 	<summary>TOTP two-factor provider</summary>
 	<description>A Two-Factor-Auth Provider for TOTP (RFC 6238)</description>
-	<version>2.1.1</version>
+	<version>2.1.2</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
 	<namespace>TwoFactorTOTP</namespace>

--- a/lib/Migration/Version020102Date20190304124405.php
+++ b/lib/Migration/Version020102Date20190304124405.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\TwoFactorTOTP\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\Migration\IOutput;
+
+class Version020102Date20190304124405 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 *
+	 * @return ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('twofactor_totp_secrets');
+		if (!$table->hasColumn('state')) {
+			$table->addColumn('state', 'integer', [
+				'notnull' => true,
+				'default' => 2,
+			]);
+		}
+		if (!$table->hasPrimaryKey()) {
+			$table->setPrimaryKey(['id']);
+		}
+		if (!$table->hasIndex('totp_secrets_user_id')) {
+			$table->addUniqueIndex(['user_id'], 'totp_secrets_user_id');
+		}
+
+		return $schema;
+	}
+
+}


### PR DESCRIPTION
Fixes https://github.com/nextcloud/twofactor_totp/issues/411

@nickvergessen does that make sense? The problem was that some instances tried to migrate where the schema wasn't up to date and therefore afterwards the `state` columns was missing.