### PR TITLE
Move to rullzer/easytotp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,7 +106,7 @@ matrix:
       env: "DB=mysql SAUCE=TRUE SELENIUM_BROWSER=firefox"
     - php: 7.2
       env: "DB=mysql SAUCE=TRUE SELENIUM_BROWSER=chrome"
-    - php: 7.0
+    - php: 7.1
       env: "DB=mysql CORE_BRANCH=stable15"
     - php: 7.1
       env: "DB=mysql CORE_BRANCH=v15.0.0"

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<name>Two-Factor TOTP Provider</name>
 	<summary>TOTP two-factor provider</summary>
 	<description>A Two-Factor-Auth Provider for TOTP (RFC 6238)</description>
-	<version>2.1.2</version>
+	<version>3.0.0</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
 	<namespace>TwoFactorTOTP</namespace>
@@ -17,7 +17,7 @@
 	<screenshot>https://raw.githubusercontent.com/nextcloud/twofactor_totp/dd1e48deec73a250886f35f3924186f5357f4c5f/screenshots/enter_challenge.png</screenshot>
 	<screenshot>https://raw.githubusercontent.com/nextcloud/twofactor_totp/dd1e48deec73a250886f35f3924186f5357f4c5f/screenshots/settings.png</screenshot>
 	<dependencies>
-		<php min-version="7.0" max-version="7.3" />
+		<php min-version="7.1" max-version="7.3" />
 		<nextcloud min-version="15" max-version="16" />
 	</dependencies>
 	<two-factor-providers>

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,8 @@
 	"require": {
 		"christian-riesen/otp": "2.*",
 		"endroid/qr-code": "^2.5",
-		"christian-riesen/base32": "^1.3"
+		"christian-riesen/base32": "^1.3",
+		"rullzer/easytotp": "^0.1.3"
 	},
 	"require-dev": {
 		"christophwurst/nextcloud": "dev-master",
@@ -19,7 +20,7 @@
 		"optimize-autoloader": true,
 		"classmap-authoritative": true,
 		"platform": {
-			"php": "7.0"
+			"php": "7.1"
 		}
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "68638fe80086d6a1565e6d2428728d3b",
+    "content-hash": "b6bf3499a92659f34a6162e85572bc67",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -438,6 +438,54 @@
                 "random"
             ],
             "time": "2018-07-04T16:31:37+00:00"
+        },
+        {
+            "name": "rullzer/easytotp",
+            "version": "v0.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rullzer/easytotp.git",
+                "reference": "2abb51ed20ae250a205061a3cbaeef2cb06d570e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rullzer/easytotp/zipball/2abb51ed20ae250a205061a3cbaeef2cb06d570e",
+                "reference": "2abb51ed20ae250a205061a3cbaeef2cb06d570e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "EasyTOTP\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roeland Jago Douma",
+                    "email": "roeland@famdouma.nl",
+                    "homepage": "http://rullzer.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Time-Based One-Time Password according to RFC6238",
+            "homepage": "https://github.com/rullzer/easytotp",
+            "keywords": [
+                "googleauthenticator",
+                "otp",
+                "rfc6238",
+                "totp"
+            ],
+            "time": "2019-03-05T12:09:03+00:00"
         },
         {
             "name": "symfony/options-resolver",
@@ -2376,6 +2424,6 @@
     "platform": [],
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.0"
+        "php": "7.1"
     }
 }

--- a/lib/Db/TotpSecret.php
+++ b/lib/Db/TotpSecret.php
@@ -32,6 +32,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setSecret(string $secret)
  * @method int getState()
  * @method void setState(int $state)
+ * @method int getLastCounter();
+ * @method void setLastCounter(int $counter)
  */
 class TotpSecret extends Entity {
 
@@ -43,5 +45,15 @@ class TotpSecret extends Entity {
 
 	/** @var int */
 	protected $state;
+
+	/** @var int */
+	protected $lastCounter;
+
+	public function __construct() {
+		$this->addType('userId', 'string');
+		$this->addType('secret', 'string');
+		$this->addType('state', 'int');
+		$this->addType('lastCounter', 'int');
+	}
 
 }

--- a/lib/Db/TotpSecretMapper.php
+++ b/lib/Db/TotpSecretMapper.php
@@ -44,7 +44,7 @@ class TotpSecretMapper extends QBMapper {
 		/* @var $qb IQueryBuilder */
 		$qb = $this->db->getQueryBuilder();
 
-		$qb->select('id', 'user_id', 'secret', 'state')
+		$qb->select('id', 'user_id', 'secret', 'state', 'last_counter')
 			->from($this->getTableName())
 			->from('twofactor_totp_secrets')
 			->where($qb->expr()->eq('user_id', $qb->createNamedParameter($user->getUID())));

--- a/lib/Migration/Version030000Date20190305114917.php
+++ b/lib/Migration/Version030000Date20190305114917.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace OCA\TwoFactorTOTP\Migration;
+
+use Closure;
+use Doctrine\DBAL\Types\Type;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\Migration\IOutput;
+
+class Version030000Date20190305114917 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('twofactor_totp_secrets');
+		$table->addColumn('last_counter', Type::BIGINT, [
+			'notnull' => true,
+			'default' => -1,
+		]);
+
+		return $schema;
+	}
+}


### PR DESCRIPTION
Fixes #479 

- [x] Move to rullzer/easytotp
- [x] Save timecounter in DB
- [x] pass timecounter to lib

Future work:
- Seems that we also use the old lib to generate a valid secret. We could just do this ourselfs I guess.