### PR TITLE
Recommends FreeOTPPlus instead of FreeOTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Tested with the following apps:
 * [andOTP](https://github.com/andOTP/andOTP) (open source) Availabe via [F-Droid](https://f-droid.org/packages/org.shadowice.flocke.andotp/) and [Google Play](https://play.google.com/store/apps/details?id=org.shadowice.flocke.andotp). It features a built-in QR-code reader.
-* [FreeOTP Authenticator](https://freeotp.github.io/) (open source) Availabe via [F-droid](https://f-droid.org/en/packages/org.fedorahosted.freeotp/), [Google Play](https://play.google.com/store/apps/details?id=org.fedorahosted.freeotp), and [Apple's App Store](https://itunes.apple.com/us/app/freeotp-authenticator/id872559395?mt=8)
+* [FreeOTPPlus](https://github.com/helloworld1/FreeOTPPlus/) (open source) Availabe via [F-droid](https://f-droid.org/packages/org.liberty.android.freeotpplus/) and [Google Play](https://play.google.com/store/apps/details?id=org.liberty.android.freeotpplus).
 * [OTP Authenticator](https://github.com/0xbb/otp-authenticator) (open source) Availabe via [F-Droid](https://f-droid.org/en/packages/net.bierbaumer.otp_authenticator/) and [Google Play](https://play.google.com/store/apps/details?id=net.bierbaumer.otp_authenticator). It features a built-in QR-code reader.
 * [Google Authenticator](https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2) (proprietary)
 * [KeePassXC (Linux, Windows, macOS)](https://keepassxc.org/) (open-source) Available via [download](https://keepassxc.org/download/), package repositories or [GitHub](http://www.github.com/keepassxreboot/keepassxc/) (Keepass also provides a plugin and Keepass2Android allows to use TOTP token)


### PR DESCRIPTION
FreeOTPPlus is an actively maintained fork of FreeOTP. FreeOTP appears abandoned; e.g. the FDroid release hasn't been updated for 4 years.

Confirmed was able to use FreeOTPPlus (the FDroid version) to set up a second factor in Nextcloud.
Issue #824