### PR TITLE
[stable25] Bump version to be higher then the last appstore

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<name>Two-Factor TOTP Provider</name>
 	<summary>TOTP two-factor provider</summary>
 	<description>A Two-Factor-Auth Provider for TOTP (RFC 6238)</description>
-	<version>6.4.0-alpha.2</version>
+	<version>7.0.0</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
 	<namespace>TwoFactorTOTP</namespace>


### PR DESCRIPTION
Master was behind stable6.4 on the version

Signed-off-by: Joas Schilling <213943+nickvergessen@users.noreply.github.com>