### PR TITLE
Revert "Set autocomplete attribute of input field to one-time-code"

### DIFF
--- a/templates/challenge.php
+++ b/templates/challenge.php
@@ -7,7 +7,7 @@ style('twofactor_totp', 'style');
 <p><?php p($l->t('Get the authentication code from the two-factor authentication app on your device.')) ?></p>
 
 <form method="POST" class="totp-form">
-	<input type="tel" minlength="6" maxlength="10" name="challenge" required="required" autofocus autocomplete="one-time-code" autocapitalize="off" placeholder="<?php p($l->t('Authentication code')) ?>">
+	<input type="tel" minlength="6" maxlength="10" name="challenge" required="required" autofocus autocomplete="off" autocapitalize="off" placeholder="<?php p($l->t('Authentication code')) ?>">
 	<button class="primary two-factor-submit" type="submit">
 		<?php p($l->t('Submit')); ?>
 	</button>


### PR DESCRIPTION
Reverts nextcloud/twofactor_totp#1148

Sadly "one-time-code" is still not supported on Firefox 106.0.2 and Chromium 106.0.52.

I've tested with these two browsers and the current state is that it's showing older codes, which is not good.
Also I can confirm that setting it back to "off" doesn't show the dropdown.

Let's revert this as Firefox and Chromium is more commonly used.

Once browsers catch up we can switch to one-time-code again.

@ChristophWurst FYI