### PR TITLE
Backport translations to 6.4

### DIFF
--- a/.tx/backport
+++ b/.tx/backport
@@ -1,0 +1,1 @@
+stable6.4 stable25


### PR DESCRIPTION
Need to manually add stable26 when that goes out and when 24 is going EOL in May we can remove the file again.