### PR TITLE
chore: Bump major version

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<name>Two-Factor TOTP Provider</name>
 	<summary>TOTP two-factor provider</summary>
 	<description>A Two-Factor-Auth Provider for TOTP (RFC 6238)</description>
-	<version>8.1.0-alpha.0</version>
+	<version>9.0.0-alpha.1</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
 	<namespace>TwoFactorTOTP</namespace>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "twofactor_totp",
-  "version": "8.0.0-alpha0",
+  "version": "9.0.0-alpha1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "twofactor_totp",
-      "version": "8.0.0-alpha0",
+      "version": "9.0.0-alpha1",
       "license": "agpl",
       "dependencies": {
         "@chenfengyuan/vue-qrcode": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "twofactor_totp",
   "description": "Nextcloud TwoFactor TOTP",
-  "version": "8.1.0-alpha0",
+  "version": "9.0.0-alpha1",
   "author": "Christoph Wurst <christoph@winzerhof-wurst.at>",
   "license": "agpl",
   "private": true,


### PR DESCRIPTION
The `master` branch dropped 26 support in https://github.com/nextcloud/twofactor_totp/pull/1336.

Ref https://docs.nextcloud.com/server/latest/developer_manual/app_publishing_maintenance/release_process.html#id1