### PR TITLE
ci(accepancetests): Limit concurrency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,9 @@ jobs:
           fail_ci_if_error: true
 
   acceptance-tests:
+    concurrency:
+      group: acceptance-tests
+      cancel-in-progress: true
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
Acceptance tests run for the same limited sauce labs instances and cause each other to time out. By limiting the concurrency I hope that tests pass more often.

Ref https://docs.github.com/en/actions/using-jobs/using-concurrency