### PR TITLE
ci: Do not build pushes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,6 @@ name: Test
 
 on:
   pull_request:
-  push:
     branches:
       - main
       - master


### PR DESCRIPTION
Pushes burn CI time with no benefit.

Building pull requests is sufficient for this repo.