### PR TITLE
chore(deps): Fix renovate base branch

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,7 +22,7 @@
 	"rebaseWhen": "conflicted",
 	"ignoreUnstable": false,
 	"baseBranches": [
-		"main",
+		"master",
 		"stable26",
 		"stable25",
 		"stable24"


### PR DESCRIPTION
This app still uses a `master` branch, not `main`.

This is a copy-paste error.

Ref https://github.com/nextcloud/twofactor_totp/issues/1355