### PR TITLE
ci: Do not cancel concurrent acceptance tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,6 @@ jobs:
   acceptance-tests:
     concurrency:
       group: acceptance-tests
-      cancel-in-progress: true
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
Follow-up to https://github.com/nextcloud/twofactor_totp/pull/1345. Apparently I configured Github actions to cancel other jobs iwth the same concurrency identifier. This breaks the automatic run of acceptance tests because there is always one job that kills the other. It could also be that multiple PRs influence each other.

Ref https://docs.github.com/en/actions/using-jobs/using-concurrency (which I still don't fully understand)