### PR TITLE
ci(test): remove nextcloud/ocp before running acceptance tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,6 +143,7 @@ jobs:
         working-directory: nextcloud/apps/twofactor_totp
         run: |
           composer install
+          composer remove --dev nextcloud/ocp
           npm ci
 
       - name: Build the app


### PR DESCRIPTION
Fix #1410 

This is an evil hack but I prefer actually running acceptance tests.

Ref https://github.com/nextcloud/twofactor_totp/pull/1338#discussion_r1153214393 for a proper solution