### PR TITLE
fix: reduce secret size to 160 bits

### DIFF
--- a/lib/Service/Totp.php
+++ b/lib/Service/Totp.php
@@ -72,7 +72,7 @@ class Totp implements ITotp {
 	}
 
 	private function generateSecret(): string {
-		return $this->random->generate(160, ISecureRandom::CHAR_UPPER.'234567');
+		return $this->random->generate(32, ISecureRandom::CHAR_UPPER.'234567');
 	}
 
 	/**


### PR DESCRIPTION
Ref https://github.com/nextcloud/twofactor_totp/issues/1324#issuecomment-1930824055

We currently have a length of `160 * 5 bit = 800 bit` which is a bit excessive.