### PR TITLE
Check if last_counter column exists before creation

### DIFF
--- a/lib/Migration/Version030000Date20190305114917.php
+++ b/lib/Migration/Version030000Date20190305114917.php
@@ -22,7 +22,7 @@ class Version030000Date20190305114917 extends SimpleMigrationStep {
 		$schema = $schemaClosure();
 
 		$table = $schema->getTable('twofactor_totp_secrets');
-		if (!$table->hasColumn('last_counter')){
+		if (!$table->hasColumn('last_counter')) {
 			// TODO: use \OCP\DB\Types::BIGINT
 			$table->addColumn('last_counter', 'bigint', [
 				'notnull' => true,

--- a/lib/Migration/Version030000Date20190305114917.php
+++ b/lib/Migration/Version030000Date20190305114917.php
@@ -22,12 +22,13 @@ class Version030000Date20190305114917 extends SimpleMigrationStep {
 		$schema = $schemaClosure();
 
 		$table = $schema->getTable('twofactor_totp_secrets');
-		// TODO: use \OCP\DB\Types::BIGINT
-		$table->addColumn('last_counter', 'bigint', [
-			'notnull' => true,
-			'default' => -1,
-		]);
-
+		if (!$table->hasColumn('last_counter')){
+			// TODO: use \OCP\DB\Types::BIGINT
+			$table->addColumn('last_counter', 'bigint', [
+				'notnull' => true,
+				'default' => -1,
+			]);
+		}
 		return $schema;
 	}
 }


### PR DESCRIPTION
If an attempt is made to activate the application on an instance where the `last_counter` column already exists, the installation fails.

Just need to add the conditional to check that the column does not already exist.