### PR TITLE
ci(test): set saucelabs region to eu

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -165,6 +165,7 @@ jobs:
         with:
           username: ${{ secrets.SAUCE_USERNAME }}
           accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}
+          region: eu
           tunnelIdentifier: "${{ github.run_id }}-${{ matrix.nextcloud-version }}-php${{ matrix.php-version }}-${{ matrix.browser }}"
 
       - name: Run tests


### PR DESCRIPTION
To fix CI. Apparently, the region has to be set explicitly since some time and the action is not pinned to a version.