### PR TITLE
chore(deps): explicitly require cs-fixer

### DIFF
--- a/vendor-bin/cs-fixer/composer.json
+++ b/vendor-bin/cs-fixer/composer.json
@@ -1,5 +1,6 @@
 {
     "require-dev": {
-        "nextcloud/coding-standard": "1.4.0"
+        "nextcloud/coding-standard": "1.4.0",
+        "php-cs-fixer/shim": "^3.64"
     }
 }

--- a/vendor-bin/cs-fixer/composer.lock
+++ b/vendor-bin/cs-fixer/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cb754a20ec396f6d35308d8fab562823",
+    "content-hash": "34212819ad723a6282ab93ab7fff6b8d",
     "packages": [],
     "packages-dev": [
         {


### PR DESCRIPTION
This makes the package visible to Renovate and therefore will cause automatic update PRs.
The current version is not yet compatible with PHP8.4.

The same trick was done for Mail: https://github.com/nextcloud/mail/pull/11268