### PR TITLE
fix: Remove duplicate from() call which just sets the same table again

### DIFF
--- a/lib/Db/TotpSecretMapper.php
+++ b/lib/Db/TotpSecretMapper.php
@@ -35,7 +35,6 @@ class TotpSecretMapper extends QBMapper {
 
 		$qb->select('id', 'user_id', 'secret', 'state', 'last_counter')
 			->from($this->getTableName())
-			->from('twofactor_totp_secrets')
 			->where($qb->expr()->eq('user_id', $qb->createNamedParameter($user->getUID())));
 		$result = $qb->executeQuery();
 


### PR DESCRIPTION
No actual here, the query is the same as before:
```sql
"SELECT `id`, `user_id`, `secret`, `state`, `last_counter` FROM `*PREFIX*twofactor_totp_secrets` WHERE `user_id` = :dcValue1"
```