### PR TITLE
fix: replace deprecated IAppContainer with PSR-11 ContainerInterface

### DIFF
--- a/lib/Provider/TotpProvider.php
+++ b/lib/Provider/TotpProvider.php
@@ -13,7 +13,6 @@ use OCA\TwoFactorTOTP\AppInfo\Application;
 use OCA\TwoFactorTOTP\Exception\NoTotpSecretFoundException;
 use OCA\TwoFactorTOTP\Service\ITotp;
 use OCA\TwoFactorTOTP\Settings\Personal;
-use OCP\AppFramework\IAppContainer;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\Authentication\TwoFactorAuth\IActivatableAtLogin;
 use OCP\Authentication\TwoFactorAuth\IDeactivatableByAdmin;
@@ -27,6 +26,7 @@ use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\Template;
 use Override;
+use Psr\Container\ContainerInterface;
 
 /** @psalm-api */
 class TotpProvider implements IProvider, IProvidesIcons, IProvidesPersonalSettings, IDeactivatableByAdmin, IActivatableAtLogin {
@@ -34,7 +34,7 @@ class TotpProvider implements IProvider, IProvidesIcons, IProvidesPersonalSettin
 	public function __construct(
 		private readonly ITotp $totp,
 		private readonly IL10N $l10n,
-		private readonly IAppContainer $container,
+		private readonly ContainerInterface $container,
 		private readonly IInitialState $initialState,
 		private readonly IURLGenerator $urlGenerator,
 	) {
@@ -122,6 +122,6 @@ class TotpProvider implements IProvider, IProvidesIcons, IProvidesPersonalSettin
 
 	#[Override]
 	public function getLoginSetup(IUser $user): ILoginSetupProvider {
-		return $this->container->query(AtLoginProvider::class);
+		return $this->container->get(AtLoginProvider::class);
 	}
 }

--- a/tests/Unit/Provider/TotpProviderTest.php
+++ b/tests/Unit/Provider/TotpProviderTest.php
@@ -16,12 +16,12 @@ use OCA\TwoFactorTOTP\Provider\AtLoginProvider;
 use OCA\TwoFactorTOTP\Provider\TotpProvider;
 use OCA\TwoFactorTOTP\Service\ITotp;
 use OCA\TwoFactorTOTP\Settings\Personal;
-use OCP\AppFramework\IAppContainer;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\IUser;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Container\ContainerInterface;
 
 class TotpProviderTest extends TestCase {
 
@@ -31,7 +31,7 @@ class TotpProviderTest extends TestCase {
 	/** @var IL10N|MockObject */
 	private $l10n;
 
-	/** @var IAppContainer|MockObject */
+	/** @var ContainerInterface|MockObject */
 	private $container;
 
 	/** @var IInitialStateService|MockObject */
@@ -48,7 +48,7 @@ class TotpProviderTest extends TestCase {
 
 		$this->totp = $this->createMock(ITotp::class);
 		$this->l10n = $this->createMock(IL10N::class);
-		$this->container = $this->createMock(IAppContainer::class);
+		$this->container = $this->createMock(ContainerInterface::class);
 		$this->initialState = $this->createMock(IInitialState::class);
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 
@@ -173,7 +173,7 @@ class TotpProviderTest extends TestCase {
 		$user = $this->createStub(IUser::class);
 		$provider = $this->createStub(AtLoginProvider::class);
 		$this->container->expects($this->once())
-			->method('query')
+			->method('get')
 			->with(AtLoginProvider::class)
 			->willReturn($provider);
 


### PR DESCRIPTION
OCP\AppFramework\IAppContainer is deprecated in favour of the standard Psr\Container\ContainerInterface. Switch TotpProvider (and its test) to use ContainerInterface and the PSR-11 get() method instead of query().

Fixes #1713