### PR TITLE
fix: handle potentially null return value of preg_replace

### DIFF
--- a/lib/Provider/TotpProvider.php
+++ b/lib/Provider/TotpProvider.php
@@ -77,7 +77,7 @@ class TotpProvider implements IProvider, IProvidesIcons, IProvidesPersonalSettin
 	 */
 	#[Override]
 	public function verifyChallenge(IUser $user, string $challenge): bool {
-		$challenge = preg_replace('/[^0-9]/', '', $challenge);
+		$challenge = preg_replace('/[^0-9]/', '', $challenge) ?? '';
 		try {
 			$secret = $this->totp->getSecret($user);
 		} catch (NoTotpSecretFoundException) {


### PR DESCRIPTION
## Summary

`preg_replace()` has a return type of `string|array|null` — it returns `null` on error. The result was passed directly to `ITotp::validateSecret()` which requires a `string`, making this a `PossiblyNullArgument` type error.

Add a `?? ''` null-coalescing fallback so the type is narrowed to `string` before it is used.

Detected by Psalm v7 (`PossiblyNullArgument`).