### PR TITLE
feat: allow admins to configure TOTP algorithm and secret length

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,38 @@ The app is available through the [app store](https://apps.nextcloud.com/apps/two
 ![](screenshots/enter_challenge.png)
 ![](screenshots/settings.png)
 
+## Admin configuration
+
+Administrators can harden TOTP settings via `occ`. Changes only affect newly enrolled secrets; existing enrollments continue to work with the algorithm they were created with.
+
+### Hash algorithm
+
+The default algorithm is SHA1 as required by [RFC 6238](https://datatracker.ietf.org/doc/html/rfc6238). Stricter environments may prefer SHA256 or SHA512, provided all users' authenticator apps support the chosen algorithm.
+
+| Value | Algorithm |
+|-------|-----------|
+| `sha1` | SHA1 (default) |
+| `sha256` | SHA256 |
+| `sha512` | SHA512 |
+
+```sh
+occ config:app:set twofactor_totp --type=string algorithm --value=sha256
+```
+
+### Secret length
+
+The generated TOTP secret defaults to 32 Base32 characters (160 bits), which meets the recommendation in [RFC 4226](https://datatracker.ietf.org/doc/html/rfc4226#section-4). Administrators can increase this for higher entropy requirements.
+
+| | Characters | Bits |
+|-|------------|------|
+| Minimum | 26 | 130 |
+| Default | 32 | 160 |
+| Maximum | 128 | 640 |
+
+```sh
+occ config:app:set twofactor_totp --type=integer secret_length --value=64
+```
+
 ## Login with external apps
 Once you enable OTP with Two Factor Totp, your applications (for example your Android app or your GNOME app) will need to login using device passwords. To manage it, [know more here](https://docs.nextcloud.com/server/stable/user_manual/en/session_management.html#managing-devices)
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -9,7 +9,7 @@
 	<name>Two-Factor TOTP Provider</name>
 	<summary>Two-factor TOTP provider</summary>
 	<description>A two-factor authentication provider for TOTP (RFC 6238)</description>
-	<version>17.0.0-dev.0</version>
+	<version>17.1.0</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
 	<namespace>TwoFactorTOTP</namespace>

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -68,10 +68,12 @@ class SettingsController extends ALoginSetupController {
 				]);
 			case ITotp::STATE_CREATED:
 				$secret = $this->totp->createSecret($user);
+				$dbSecret = $this->totp->getSecret($user);
 
 				$secretName = $this->getSecretName();
 				$issuer = $this->getSecretIssuer();
-				$qrUrl = "otpauth://totp/$secretName?secret=$secret&issuer=$issuer";
+				$algorithm = strtoupper($dbSecret->getAlgorithm());
+				$qrUrl = "otpauth://totp/$secretName?secret=$secret&issuer=$issuer&algorithm=$algorithm";
 				return new JSONResponse([
 					'state' => ITotp::STATE_CREATED,
 					'secret' => $secret,

--- a/lib/Db/TotpSecret.php
+++ b/lib/Db/TotpSecret.php
@@ -19,8 +19,10 @@ use OCP\AppFramework\Db\Entity;
  * @method void setSecret(string $secret)
  * @method int getState()
  * @method void setState(int $state)
- * @method int getLastCounter();
+ * @method int getLastCounter()
  * @method void setLastCounter(int $counter)
+ * @method string getAlgorithm()
+ * @method void setAlgorithm(string $algorithm)
  */
 class TotpSecret extends Entity {
 
@@ -36,10 +38,14 @@ class TotpSecret extends Entity {
 	/** @var int */
 	protected $lastCounter;
 
+	/** @var string */
+	protected $algorithm;
+
 	public function __construct() {
 		$this->addType('userId', 'string');
 		$this->addType('secret', 'string');
 		$this->addType('state', 'integer');
 		$this->addType('lastCounter', 'integer');
+		$this->addType('algorithm', 'string');
 	}
 }

--- a/lib/Db/TotpSecretMapper.php
+++ b/lib/Db/TotpSecretMapper.php
@@ -34,7 +34,7 @@ class TotpSecretMapper extends QBMapper {
 		/* @var $qb IQueryBuilder */
 		$qb = $this->db->getQueryBuilder();
 
-		$qb->select('id', 'user_id', 'secret', 'state', 'last_counter')
+		$qb->select('id', 'user_id', 'secret', 'state', 'last_counter', 'algorithm')
 			->from($this->getTableName())
 			->where($qb->expr()->eq('user_id', $qb->createNamedParameter($user->getUID())));
 		$result = $qb->executeQuery();

--- a/lib/Migration/Version170100Date20260611120000.php
+++ b/lib/Migration/Version170100Date20260611120000.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2024 Raphael Gradenwitz <raphael.gradenwitz@googlemail.com>
+ * SPDX-FileCopyrightText: 2026 Christoph Wurst <christoph@winzerhof-wurst.at>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorTOTP\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+use Override;
+
+/** @psalm-api */
+class Version170100Date20260611120000 extends SimpleMigrationStep {
+
+	#[Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+		$table = $schema->getTable('twofactor_totp_secrets');
+
+		if (!$table->hasColumn('algorithm')) {
+			$table->addColumn('algorithm', Types::STRING, [
+				'notnull' => true,
+				'length' => 10,
+				'default' => 'sha1',
+			]);
+		}
+
+		return $schema;
+	}
+}

--- a/lib/Service/ITotp.php
+++ b/lib/Service/ITotp.php
@@ -20,6 +20,18 @@ interface ITotp {
 	public const STATE_CREATED = 1;
 	public const STATE_ENABLED = 2;
 
+	public const ALGORITHM_SHA1 = 'sha1';
+	public const ALGORITHM_SHA256 = 'sha256';
+	public const ALGORITHM_SHA512 = 'sha512';
+	public const DEFAULT_ALGORITHM = self::ALGORITHM_SHA1;
+
+	/** Minimum secret length in Base32 characters (130 bits) */
+	public const MIN_SECRET_LENGTH = 26;
+	/** Default secret length in Base32 characters (160 bits, per RFC 4226 recommendation) */
+	public const DEFAULT_SECRET_LENGTH = 32;
+	/** Maximum secret length in Base32 characters */
+	public const MAX_SECRET_LENGTH = 128;
+
 	public function hasSecret(IUser $user): bool;
 
 	/**

--- a/lib/Service/Totp.php
+++ b/lib/Service/Totp.php
@@ -18,6 +18,7 @@ use OCA\TwoFactorTOTP\Event\DisabledByAdmin;
 use OCA\TwoFactorTOTP\Event\StateChanged;
 use OCA\TwoFactorTOTP\Exception\NoTotpSecretFoundException;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Services\IAppConfig;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IUser;
 use OCP\Security\ICrypto;
@@ -32,7 +33,26 @@ class Totp implements ITotp {
 		private readonly ICrypto $crypto,
 		private readonly IEventDispatcher $eventDispatcher,
 		private readonly ISecureRandom $random,
+		private readonly IAppConfig $appConfig,
 	) {
+	}
+
+	private function getSecretLength(): int {
+		$length = $this->appConfig->getAppValueInt('secret_length', ITotp::DEFAULT_SECRET_LENGTH);
+		if ($length >= ITotp::MIN_SECRET_LENGTH && $length <= ITotp::MAX_SECRET_LENGTH) {
+			return $length;
+		}
+		return ITotp::DEFAULT_SECRET_LENGTH;
+	}
+
+	private function getDefaultAlgorithm(): string {
+		$algorithm = $this->appConfig->getAppValueString('algorithm', ITotp::DEFAULT_ALGORITHM);
+		$valid = [
+			ITotp::ALGORITHM_SHA1,
+			ITotp::ALGORITHM_SHA256,
+			ITotp::ALGORITHM_SHA512,
+		];
+		return in_array($algorithm, $valid, true) ? $algorithm : ITotp::DEFAULT_ALGORITHM;
 	}
 
 	#[Override]
@@ -46,7 +66,7 @@ class Totp implements ITotp {
 	}
 
 	private function generateSecret(): string {
-		return $this->random->generate(32, ISecureRandom::CHAR_UPPER . '234567');
+		return $this->random->generate($this->getSecretLength(), ISecureRandom::CHAR_UPPER . '234567');
 	}
 
 	/**
@@ -69,6 +89,7 @@ class Totp implements ITotp {
 		$dbSecret->setUserId($user->getUID());
 		$dbSecret->setSecret($this->crypto->encrypt($secret));
 		$dbSecret->setState(ITotp::STATE_CREATED);
+		$dbSecret->setAlgorithm($this->getDefaultAlgorithm());
 
 		$this->secretMapper->insert($dbSecret);
 		return $secret;
@@ -121,7 +142,8 @@ class Totp implements ITotp {
 	#[Override]
 	public function validateSecret(TotpSecret $secret, string $key): bool {
 		$decryptedSecret = $this->crypto->decrypt($secret->getSecret());
-		$otp = Factory::getTOTP(Base32::decode($decryptedSecret), 30, 6);
+		$algorithm = $secret->getAlgorithm() ?: ITotp::DEFAULT_ALGORITHM;
+		$otp = Factory::getTOTP(Base32::decode($decryptedSecret), 30, 6, 0, $algorithm);
 
 		$counter = null;
 		$lastCounter = $secret->getLastCounter();

--- a/tests/Unit/Controller/SettingsControllerTest.php
+++ b/tests/Unit/Controller/SettingsControllerTest.php
@@ -10,8 +10,8 @@ namespace OCA\TwoFactorTOTP\Unit\Controller;
 
 use InvalidArgumentException;
 use OCA\TwoFactorTOTP\Controller\SettingsController;
+use OCA\TwoFactorTOTP\Db\TotpSecret;
 use OCA\TwoFactorTOTP\Service\ITotp;
-use OCA\TwoFactorTOTP\Service\Totp;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\Defaults;
 use OCP\IRequest;
@@ -30,7 +30,7 @@ final class SettingsControllerTest extends TestCase {
 	protected function setUp(): void {
 		$request = $this->createMock(IRequest::class);
 		$this->userSession = $this->createMock(IUserSession::class);
-		$this->totp = $this->createMock(Totp::class);
+		$this->totp = $this->createMock(ITotp::class);
 		$this->defaults = new Defaults();
 
 		$this->controller = new SettingsController('twofactor_totp', $request, $this->userSession, $this->totp, $this->defaults);
@@ -65,11 +65,45 @@ final class SettingsControllerTest extends TestCase {
 			->method('createSecret')
 			->with($user)
 			->willReturn('newsecret');
+		$dbSecret = new TotpSecret();
+		$dbSecret->setAlgorithm(ITotp::ALGORITHM_SHA1);
+		$this->totp->expects($this->once())
+			->method('getSecret')
+			->with($user)
+			->willReturn($dbSecret);
 		$issuer = rawurlencode((string)$this->defaults->getName());
 		$expected = new JSONResponse([
 			'state' => ITotp::STATE_CREATED,
 			'secret' => 'newsecret',
-			'qrUrl' => "otpauth://totp/$issuer%3Auser%40instance.com?secret=newsecret&issuer=$issuer",
+			'qrUrl' => "otpauth://totp/$issuer%3Auser%40instance.com?secret=newsecret&issuer=$issuer&algorithm=SHA1",
+		]);
+
+		$this->assertEquals($expected, $this->controller->enable(ITotp::STATE_CREATED));
+	}
+
+	public function testCreateSecretWithNonDefaultAlgorithm(): void {
+		$user = $this->createMock(IUser::class);
+		$this->userSession->expects($this->exactly(2))
+			->method('getUser')
+			->willReturn($user);
+		$user->expects($this->once())
+			->method('getCloudId')
+			->willReturn('user@instance.com');
+		$this->totp->expects($this->once())
+			->method('createSecret')
+			->with($user)
+			->willReturn('newsecret');
+		$dbSecret = new TotpSecret();
+		$dbSecret->setAlgorithm(ITotp::ALGORITHM_SHA256);
+		$this->totp->expects($this->once())
+			->method('getSecret')
+			->with($user)
+			->willReturn($dbSecret);
+		$issuer = rawurlencode((string)$this->defaults->getName());
+		$expected = new JSONResponse([
+			'state' => ITotp::STATE_CREATED,
+			'secret' => 'newsecret',
+			'qrUrl' => "otpauth://totp/$issuer%3Auser%40instance.com?secret=newsecret&issuer=$issuer&algorithm=SHA256",
 		]);
 
 		$this->assertEquals($expected, $this->controller->enable(ITotp::STATE_CREATED));

--- a/tests/Unit/Service/TotpTest.php
+++ b/tests/Unit/Service/TotpTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2024 Raphael Gradenwitz <raphael.gradenwitz@googlemail.com>
+ * SPDX-FileCopyrightText: 2026 Christoph Wurst <christoph@winzerhof-wurst.at>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorTOTP\Unit\Service;
+
+use OCA\TwoFactorTOTP\Db\TotpSecret;
+use OCA\TwoFactorTOTP\Db\TotpSecretMapper;
+use OCA\TwoFactorTOTP\Service\ITotp;
+use OCA\TwoFactorTOTP\Service\Totp;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Services\IAppConfig;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IUser;
+use OCP\Security\ICrypto;
+use OCP\Security\ISecureRandom;
+use PHPUnit\Framework\TestCase;
+
+class TotpTest extends TestCase {
+
+	private TotpSecretMapper $secretMapper;
+	private ICrypto $crypto;
+	private IEventDispatcher $eventDispatcher;
+	private ISecureRandom $random;
+	private IAppConfig $appConfig;
+	private Totp $totp;
+
+	protected function setUp(): void {
+		$this->secretMapper = $this->createMock(TotpSecretMapper::class);
+		$this->crypto = $this->createMock(ICrypto::class);
+		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
+		$this->random = $this->createMock(ISecureRandom::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
+
+		$this->totp = new Totp(
+			$this->secretMapper,
+			$this->crypto,
+			$this->eventDispatcher,
+			$this->random,
+			$this->appConfig,
+		);
+	}
+
+	private function stubNoExistingSecret(): void {
+		$this->secretMapper->method('getSecret')
+			->willThrowException(new DoesNotExistException(''));
+	}
+
+	public function testCreateSecretStoresDefaultAlgorithm(): void {
+		$this->stubNoExistingSecret();
+		$this->appConfig->method('getAppValueString')
+			->with('algorithm', ITotp::DEFAULT_ALGORITHM)
+			->willReturn(ITotp::DEFAULT_ALGORITHM);
+		$this->appConfig->method('getAppValueInt')
+			->willReturn(ITotp::DEFAULT_SECRET_LENGTH);
+		$this->random->method('generate')->willReturn(str_repeat('A', 32));
+		$this->crypto->method('encrypt')->willReturnArgument(0);
+
+		$this->secretMapper->expects($this->once())
+			->method('insert')
+			->with($this->callback(function (TotpSecret $entity): bool {
+				$this->assertSame(ITotp::ALGORITHM_SHA1, $entity->getAlgorithm());
+				return true;
+			}))
+			->willReturnArgument(0);
+
+		$user = $this->createStub(IUser::class);
+		$this->totp->createSecret($user);
+	}
+
+	public function testCreateSecretStoresConfiguredAlgorithm(): void {
+		$this->stubNoExistingSecret();
+		$this->appConfig->method('getAppValueString')
+			->with('algorithm', ITotp::DEFAULT_ALGORITHM)
+			->willReturn(ITotp::ALGORITHM_SHA256);
+		$this->appConfig->method('getAppValueInt')
+			->willReturn(ITotp::DEFAULT_SECRET_LENGTH);
+		$this->random->method('generate')->willReturn(str_repeat('A', 32));
+		$this->crypto->method('encrypt')->willReturnArgument(0);
+
+		$this->secretMapper->expects($this->once())
+			->method('insert')
+			->with($this->callback(function (TotpSecret $entity): bool {
+				$this->assertSame(ITotp::ALGORITHM_SHA256, $entity->getAlgorithm());
+				return true;
+			}))
+			->willReturnArgument(0);
+
+		$user = $this->createStub(IUser::class);
+		$this->totp->createSecret($user);
+	}
+
+	public function testCreateSecretFallsBackToDefaultForInvalidAlgorithm(): void {
+		$this->stubNoExistingSecret();
+		$this->appConfig->method('getAppValueString')
+			->with('algorithm', ITotp::DEFAULT_ALGORITHM)
+			->willReturn('md5');
+		$this->appConfig->method('getAppValueInt')
+			->willReturn(ITotp::DEFAULT_SECRET_LENGTH);
+		$this->random->method('generate')->willReturn(str_repeat('A', 32));
+		$this->crypto->method('encrypt')->willReturnArgument(0);
+
+		$this->secretMapper->expects($this->once())
+			->method('insert')
+			->with($this->callback(function (TotpSecret $entity): bool {
+				$this->assertSame(ITotp::DEFAULT_ALGORITHM, $entity->getAlgorithm());
+				return true;
+			}))
+			->willReturnArgument(0);
+
+		$user = $this->createStub(IUser::class);
+		$this->totp->createSecret($user);
+	}
+
+	public function testCreateSecretUsesConfiguredLength(): void {
+		$this->stubNoExistingSecret();
+		$this->appConfig->method('getAppValueString')
+			->willReturn(ITotp::DEFAULT_ALGORITHM);
+		$this->appConfig->method('getAppValueInt')
+			->with('secret_length', ITotp::DEFAULT_SECRET_LENGTH)
+			->willReturn(64);
+		$this->crypto->method('encrypt')->willReturnArgument(0);
+
+		$this->random->expects($this->once())
+			->method('generate')
+			->with(64, ISecureRandom::CHAR_UPPER . '234567')
+			->willReturn(str_repeat('A', 64));
+
+		$this->secretMapper->method('insert')->willReturnArgument(0);
+
+		$user = $this->createStub(IUser::class);
+		$this->totp->createSecret($user);
+	}
+
+	public function testCreateSecretFallsBackToDefaultLengthWhenTooShort(): void {
+		$this->stubNoExistingSecret();
+		$this->appConfig->method('getAppValueString')
+			->willReturn(ITotp::DEFAULT_ALGORITHM);
+		$this->appConfig->method('getAppValueInt')
+			->with('secret_length', ITotp::DEFAULT_SECRET_LENGTH)
+			->willReturn(5);
+		$this->crypto->method('encrypt')->willReturnArgument(0);
+
+		$this->random->expects($this->once())
+			->method('generate')
+			->with(ITotp::DEFAULT_SECRET_LENGTH, ISecureRandom::CHAR_UPPER . '234567')
+			->willReturn(str_repeat('A', ITotp::DEFAULT_SECRET_LENGTH));
+
+		$this->secretMapper->method('insert')->willReturnArgument(0);
+
+		$user = $this->createStub(IUser::class);
+		$this->totp->createSecret($user);
+	}
+
+	public function testCreateSecretFallsBackToDefaultLengthWhenTooLong(): void {
+		$this->stubNoExistingSecret();
+		$this->appConfig->method('getAppValueString')
+			->willReturn(ITotp::DEFAULT_ALGORITHM);
+		$this->appConfig->method('getAppValueInt')
+			->with('secret_length', ITotp::DEFAULT_SECRET_LENGTH)
+			->willReturn(200);
+		$this->crypto->method('encrypt')->willReturnArgument(0);
+
+		$this->random->expects($this->once())
+			->method('generate')
+			->with(ITotp::DEFAULT_SECRET_LENGTH, ISecureRandom::CHAR_UPPER . '234567')
+			->willReturn(str_repeat('A', ITotp::DEFAULT_SECRET_LENGTH));
+
+		$this->secretMapper->method('insert')->willReturnArgument(0);
+
+		$user = $this->createStub(IUser::class);
+		$this->totp->createSecret($user);
+	}
+}


### PR DESCRIPTION
## Summary

Extracted and refined from #1549 (original author: @ernolf). This PR takes only the admin-side hardening options, leaving user-facing advanced settings and the favicon change out of scope.

- Admins can set the hash algorithm used for new TOTP secrets:
  ```sh
  occ config:app:set twofactor_totp --type=string algorithm --value=sha256
  ```
  Valid values: `sha1` (default), `sha256`, `sha512`. Invalid values fall back to `sha1`.

- Admins can increase the generated secret length for higher entropy:
  ```sh
  occ config:app:set twofactor_totp --type=integer secret_length --value=64
  ```
  Valid range: 26–128 Base32 characters (130–640 bits). Default is 32 (160 bits, per RFC 4226 recommendation). Out-of-range values fall back to the default.

The algorithm chosen at enrollment time is stored per-secret in the database and used for validation, so existing enrollments are never affected by admin config changes. The algorithm is also included in the `otpauth://` QR code URI so authenticator apps configure themselves automatically.

## Design notes

- One new DB column (`algorithm STRING`), with migration defaulting existing rows to `sha1`.
- `IAppConfig` (typed API) used instead of raw `IConfig`.
- Digits and period are intentionally **not** configurable — 6 digits is the universal TOTP standard and the security gain of 8 digits is marginal compared to the compatibility risk.

Closes #26