### PR TITLE
feat(totp): embed favicon URL in otpauth QR code

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -16,6 +16,7 @@ use OCP\AppFramework\Http\JSONResponse;
 use OCP\Authentication\TwoFactorAuth\ALoginSetupController;
 use OCP\Defaults;
 use OCP\IRequest;
+use OCP\IURLGenerator;
 use OCP\IUserSession;
 use RuntimeException;
 use function is_null;
@@ -29,6 +30,7 @@ class SettingsController extends ALoginSetupController {
 		private readonly IUserSession $userSession,
 		private readonly ITotp $totp,
 		private readonly Defaults $defaults,
+		private readonly IURLGenerator $urlGenerator,
 	) {
 		parent::__construct($appName, $request);
 	}
@@ -73,7 +75,10 @@ class SettingsController extends ALoginSetupController {
 				$secretName = $this->getSecretName();
 				$issuer = $this->getSecretIssuer();
 				$algorithm = strtoupper($dbSecret->getAlgorithm());
-				$qrUrl = "otpauth://totp/$secretName?secret=$secret&issuer=$issuer&algorithm=$algorithm";
+				$image = $this->urlGenerator->getAbsoluteURL(
+					$this->urlGenerator->linkToRoute('theming.Icon.getFavicon', ['app' => 'core'])
+				);
+				$qrUrl = "otpauth://totp/$secretName?secret=$secret&issuer=$issuer&algorithm=$algorithm&image=" . rawurlencode($image);
 				return new JSONResponse([
 					'state' => ITotp::STATE_CREATED,
 					'secret' => $secret,

--- a/tests/Unit/Controller/SettingsControllerTest.php
+++ b/tests/Unit/Controller/SettingsControllerTest.php
@@ -15,6 +15,7 @@ use OCA\TwoFactorTOTP\Service\ITotp;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\Defaults;
 use OCP\IRequest;
+use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserSession;
 use PHPUnit\Framework\TestCase;
@@ -23,6 +24,7 @@ final class SettingsControllerTest extends TestCase {
 	private $userSession;
 	private $totp;
 	private $defaults;
+	private $urlGenerator;
 
 	/** @var SettingsController */
 	private $controller;
@@ -32,8 +34,9 @@ final class SettingsControllerTest extends TestCase {
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->totp = $this->createMock(ITotp::class);
 		$this->defaults = new Defaults();
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 
-		$this->controller = new SettingsController('twofactor_totp', $request, $this->userSession, $this->totp, $this->defaults);
+		$this->controller = new SettingsController('twofactor_totp', $request, $this->userSession, $this->totp, $this->defaults, $this->urlGenerator);
 	}
 
 	public function testDisabledState(): void {
@@ -71,11 +74,21 @@ final class SettingsControllerTest extends TestCase {
 			->method('getSecret')
 			->with($user)
 			->willReturn($dbSecret);
+		$this->urlGenerator->expects($this->once())
+			->method('linkToRoute')
+			->with('theming.Icon.getFavicon', ['app' => 'core'])
+			->willReturn('/path/to/favicon');
+		$this->urlGenerator->expects($this->once())
+			->method('getAbsoluteURL')
+			->with('/path/to/favicon')
+			->willReturn('https://cloud.example.com/path/to/favicon');
+
 		$issuer = rawurlencode((string)$this->defaults->getName());
+		$image = rawurlencode('https://cloud.example.com/path/to/favicon');
 		$expected = new JSONResponse([
 			'state' => ITotp::STATE_CREATED,
 			'secret' => 'newsecret',
-			'qrUrl' => "otpauth://totp/$issuer%3Auser%40instance.com?secret=newsecret&issuer=$issuer&algorithm=SHA1",
+			'qrUrl' => "otpauth://totp/$issuer%3Auser%40instance.com?secret=newsecret&issuer=$issuer&algorithm=SHA1&image=$image",
 		]);
 
 		$this->assertEquals($expected, $this->controller->enable(ITotp::STATE_CREATED));
@@ -99,11 +112,21 @@ final class SettingsControllerTest extends TestCase {
 			->method('getSecret')
 			->with($user)
 			->willReturn($dbSecret);
+		$this->urlGenerator->expects($this->once())
+			->method('linkToRoute')
+			->with('theming.Icon.getFavicon', ['app' => 'core'])
+			->willReturn('/path/to/favicon');
+		$this->urlGenerator->expects($this->once())
+			->method('getAbsoluteURL')
+			->with('/path/to/favicon')
+			->willReturn('https://cloud.example.com/path/to/favicon');
+
 		$issuer = rawurlencode((string)$this->defaults->getName());
+		$image = rawurlencode('https://cloud.example.com/path/to/favicon');
 		$expected = new JSONResponse([
 			'state' => ITotp::STATE_CREATED,
 			'secret' => 'newsecret',
-			'qrUrl' => "otpauth://totp/$issuer%3Auser%40instance.com?secret=newsecret&issuer=$issuer&algorithm=SHA256",
+			'qrUrl' => "otpauth://totp/$issuer%3Auser%40instance.com?secret=newsecret&issuer=$issuer&algorithm=SHA256&image=$image",
 		]);
 
 		$this->assertEquals($expected, $this->controller->enable(ITotp::STATE_CREATED));


### PR DESCRIPTION
Fixes https://github.com/nextcloud/twofactor_totp/issues/1407

Extracted from https://github.com/nextcloud/twofactor_totp/pull/1549.

Embeds the Nextcloud instance favicon in the otpauth:// URI via the `image` parameter so that apps like FreeOTP can display a recognisable icon for the account.


Assisted-by: ClaudeCode:claude-sonnet-4-6

## How to test

1. Start the TOTP setup
2. Scan and decode the QR code

master: no `image` parameter
here: `image` parameter to the favicon. Since dev instances typically use localhost the scanning doesn't work for TOTP phone apps. It will work in prod deployment.

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
