### PR TITLE
[stable34] ci: update codecov action to v7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,6 @@ jobs:
         if: ${{ always() }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./nextcloud/apps/twofactor_totp/tests/clover.xml
+          files: ./nextcloud/apps/twofactor_totp/tests/clover.xml
           flags: unittests
           fail_ci_if_error: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,12 +52,15 @@ jobs:
       - name: Run tests
         working-directory: nextcloud/apps/twofactor_totp
         run: composer run test:unit
+        env:
+          XDEBUG_MODE: coverage
 
       - name: Report coverage
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./nextcloud/apps/twofactor_totp/tests/clover.xml
+          working-directory: nextcloud/apps/twofactor_totp
+          files: tests/clover.xml
           flags: unittests
-          fail_ci_if_error: true
+          fail_ci_if_error: ${{ !github.event.pull_request.head.repo.fork }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
         run: composer run test:unit
 
       - name: Report coverage
-        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         if: ${{ always() }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -11,6 +11,11 @@
       <directory suffix=".php">../lib</directory>
     </include>
   </source>
+  <coverage>
+    <report>
+      <clover outputFile="clover.xml"/>
+    </report>
+  </coverage>
   <testsuite name="TOTP 2FA Provider">
     <directory suffix="Test.php">.</directory>
   </testsuite>


### PR DESCRIPTION
Backport of #1780 to stable34, without the playwright runner change and the master-only PHP 8.3 bumps.

Fixes the unit test job failing at the codecov upload step (GPG signature verification of the old uploader).

Cherry-picked with AI assistance (Claude Code).